### PR TITLE
Increase snapcraft replicas on staging

### DIFF
--- a/staging.snapcraft.io/snapcraft.io-static-pages.yaml
+++ b/staging.snapcraft.io/snapcraft.io-static-pages.yaml
@@ -20,7 +20,7 @@ kind: Deployment
 metadata:
   name: staging-snapcraft-io-static-pages
 spec:
-  replicas: 1
+  replicas: 3
   template:
     metadata:
       labels:

--- a/staging.snapcraft.io/snapcraft.io.yaml
+++ b/staging.snapcraft.io/snapcraft.io.yaml
@@ -20,7 +20,7 @@ kind: Deployment
 metadata:
   name: staging-snapcraft-io
 spec:
-  replicas: 1
+  replicas: 3
   template:
     metadata:
       labels:


### PR DESCRIPTION
I noticed that when a new release is made to staging, the app goes down for a bit. This is probably because of the single running unit.

These images are not large, running more images should be cheap. I'm upping it to 5.