### PR TITLE
Deployment configs for docs.snapcraft.io

### DIFF
--- a/docs.snapcraft.io/README.md
+++ b/docs.snapcraft.io/README.md
@@ -1,0 +1,20 @@
+This deployment can be released file by file but it can also be released in one by pointing kubectl at the parent folder.
+
+`kubectl apply -f .`
+
+
+The configuration relies on a TLS secret which follows this format:
+
+``` yaml
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: docs-snapcraft-io-tls
+  namespace: default
+data:
+  tls.crt: dGVzdAo= # Base64 cert
+  tls.key: dGVzdAo= # Base64 key
+  ca.crt: dGVzdAo= # BAse64 chain (optional)
+```

--- a/docs.snapcraft.io/deployment-docs.snapcraft.io.yaml
+++ b/docs.snapcraft.io/deployment-docs.snapcraft.io.yaml
@@ -1,0 +1,40 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: docs-snapcraft-io
+  labels:
+    app: docs-snapcraft-io
+spec:
+  selector:
+    app: docs-snapcraft-io
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+---
+
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: docs-snapcraft-io
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: docs-snapcraft-io
+    spec:
+      containers:
+        - name: docs-snapcraft-io
+          image: prod-comms.docker-registry.canonical.com/docs.snapcraft.io
+          ports:
+            - name: http
+              containerPort: 80
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5

--- a/docs.snapcraft.io/ingress-docs.snapcraft.io.yaml
+++ b/docs.snapcraft.io/ingress-docs.snapcraft.io.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: docs-snapcraft-io
+  namespace: default
+  labels:
+    app: docs-snapcraft-io
+
+spec:
+  tls:
+  - secretName: docs-snapcraft-io-tls
+    hosts:
+    - docs.snapcraft.io
+  rules:
+  - host: docs.snapcraft.io
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: docs-snapcraft-io
+          servicePort: 80

--- a/docs.staging.snapcraft.io/README.md
+++ b/docs.staging.snapcraft.io/README.md
@@ -1,0 +1,20 @@
+This deployment can be released file by file but it can also be released in one by pointing kubectl at the parent folder.
+
+`kubectl apply -f .`
+
+
+The configuration relies on a TLS secret which follows this format:
+
+``` yaml
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: docs-staging-snapcraft-io-tls
+  namespace: default
+data:
+  tls.crt: dGVzdAo= # Base64 cert
+  tls.key: dGVzdAo= # Base64 key
+  ca.crt: dGVzdAo= # BAse64 chain (optional)
+```

--- a/docs.staging.snapcraft.io/deployment-docs.staging.snapcraft.io.yaml
+++ b/docs.staging.snapcraft.io/deployment-docs.staging.snapcraft.io.yaml
@@ -1,0 +1,40 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: docs-staging-snapcraft-io
+  labels:
+    app: docs-staging-snapcraft-io
+spec:
+  selector:
+    app: docs-staging-snapcraft-io
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+---
+
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: docs-staging-snapcraft-io
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: docs-staging-snapcraft-io
+    spec:
+      containers:
+        - name: docs-staging-snapcraft-io
+          image: prod-comms.docker-registry.canonical.com/docs.snapcraft.io
+          ports:
+            - name: http
+              containerPort: 80
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5

--- a/docs.staging.snapcraft.io/ingress-docs.staging.snapcraft.io.yaml
+++ b/docs.staging.snapcraft.io/ingress-docs.staging.snapcraft.io.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: docs-staging-snapcraft-io
+  namespace: default
+  labels:
+    app: docs-staging-snapcraft-io
+
+spec:
+  tls:
+  - secretName: docs-staging-snapcraft-io-tls
+    hosts:
+    - docs.staging.snapcraft.io
+  rules:
+  - host: docs.staging.snapcraft.io
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: docs-staging-snapcraft-io
+          servicePort: 80


### PR DESCRIPTION
To prepare for docs.snapcraft.io, which will exist very soon, here are the deployment configs for that domain, including liveness checks.

QA
--

Not really QAable yet.