### PR TITLE
Define readiness checks

### DIFF
--- a/docs.snapcraft.io/deployment-docs.snapcraft.io.yaml
+++ b/docs.snapcraft.io/deployment-docs.snapcraft.io.yaml
@@ -32,6 +32,12 @@ spec:
           ports:
             - name: http
               containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 1
+            successThreshold: 3
           livenessProbe:
             httpGet:
               path: /

--- a/docs.staging.snapcraft.io/deployment-docs.staging.snapcraft.io.yaml
+++ b/docs.staging.snapcraft.io/deployment-docs.staging.snapcraft.io.yaml
@@ -32,6 +32,12 @@ spec:
           ports:
             - name: http
               containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 1
+            successThreshold: 3
           livenessProbe:
             httpGet:
               path: /

--- a/snapcraft.io/deployment-snapcraft.io.yaml
+++ b/snapcraft.io/deployment-snapcraft.io.yaml
@@ -32,6 +32,12 @@ spec:
           ports:
             - name: http
               containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 1
+            successThreshold: 3
           livenessProbe:
             httpGet:
               path: /

--- a/staging.snapcraft.io/deployment-snapcraft.io.yaml
+++ b/staging.snapcraft.io/deployment-snapcraft.io.yaml
@@ -32,6 +32,12 @@ spec:
           ports:
             - name: http
               containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 1
+            successThreshold: 3
           livenessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
I was finding that while doing deployment rollouts, the site would slow down to the point where some requests took 15 seconds. That's not really acceptable.

Readiness checks help a lot. Kubernetes will now wait for 3 consecutive successful HTTP requests before considering a pod ready for consumption, and switch traffic over to it.

Rollouts can take up to 1 minute, and requests can still slow down to taking 3 or 4 seconds during rollouts, but it's a lot better.

Fixes https://github.com/canonical-websites/snapcraft.io/issues/79